### PR TITLE
Fix von den Rückgabewerten von den Stores

### DIFF
--- a/src/provisioning/go.mod
+++ b/src/provisioning/go.mod
@@ -4,7 +4,7 @@ go 1.23.3
 
 require (
 	github.com/golang-migrate/migrate v3.5.4+incompatible
-	github.com/google/uuid v1.6.0
+	github.com/google/go-cmp v0.6.0
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/joho/godotenv v1.5.1
@@ -18,7 +18,6 @@ require (
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/src/provisioning/go.sum
+++ b/src/provisioning/go.sum
@@ -28,8 +28,6 @@ github.com/golang-migrate/migrate v3.5.4+incompatible h1:R7OzwvCJTCgwapPCiX6DyBi
 github.com/golang-migrate/migrate v3.5.4+incompatible/go.mod h1:IsVUlFN5puWOmXrqjgGUfIRIbU7mr8oNBE2tyERd9Wk=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/src/provisioning/internal/db/backup_store.go
+++ b/src/provisioning/internal/db/backup_store.go
@@ -9,7 +9,7 @@ type ServerBackupStore struct {
 	db *sqlx.DB
 }
 
-func NewServerBackupStore(db *sqlx.DB) *ServerBackupStore {
+func NewServerBackupStore(db *sqlx.DB) Store[types.Backup] {
 	return &ServerBackupStore{db: db}
 }
 

--- a/src/provisioning/internal/db/server_store.go
+++ b/src/provisioning/internal/db/server_store.go
@@ -9,7 +9,7 @@ type ServerStore struct {
 	db *sqlx.DB
 }
 
-func NewServerStore(db *sqlx.DB) *ServerStore {
+func NewServerStore(db *sqlx.DB) Store[types.Server] {
 	return &ServerStore{db: db}
 }
 


### PR DESCRIPTION
Die stores haben die konkreten Implementierungen von dem `Store[T any]` interface zurückgegeben, wodurch man nicht mehr mit dem Interface arbeiten kann. Da wär aber cool, damit man die Services individuell testen kann.