### PR TITLE
Implementierung von Nutzerdatenabgleich mit Auth0

### DIFF
--- a/src/provisioning/internal/config/auth0.go
+++ b/src/provisioning/internal/config/auth0.go
@@ -1,0 +1,8 @@
+package config
+
+import "net/url"
+
+// Auth0Config represents Configuration related to connecting to an Auth0 Tenant
+type Auth0Config struct {
+	Url url.URL
+}

--- a/src/provisioning/internal/config/config.go
+++ b/src/provisioning/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"github.com/joho/godotenv"
 	"log"
+	"net/url"
 	"os"
 )
 
@@ -10,7 +11,8 @@ import (
 // All settings or credentials the backend needs is to be supplied here.
 type Config struct {
 	// Db configuration to access the primary database
-	Db DbConfig
+	Db    DbConfig
+	Auth0 Auth0Config
 }
 
 // LoadConfig loads the application configuration.
@@ -24,10 +26,16 @@ type Config struct {
 // DB_PORT: port for the database (default: 5432)
 // DB_USER: username for the database (default: postgres)
 // DB_PASS: password for the database (default: postgres)
+// AUTH0_URL: URL to the Auth0 Userinfo endpoint (default: http://localhost)
 func LoadConfig() *Config {
 	err := godotenv.Load()
 	if err != nil {
 		log.Println("No .env file found. Using Fallback values")
+	}
+
+	auth0, err := url.Parse(getEnv("AUTH0_URL", "http://localhost"))
+	if err != nil {
+		log.Fatalln("Invalid url for Auth0")
 	}
 
 	cfg := &Config{
@@ -36,6 +44,9 @@ func LoadConfig() *Config {
 			Port:     getEnv("DB_PORT", "5432"),
 			User:     getEnv("DB_USER", "postgres"),
 			Password: getEnv("DB_PASS", "postgres"),
+		},
+		Auth0: Auth0Config{
+			Url: *auth0,
 		},
 	}
 	return cfg

--- a/src/provisioning/internal/config/config_test.go
+++ b/src/provisioning/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/stretchr/testify/assert"
+	"net/url"
 	"os"
 	"testing"
 )
@@ -11,12 +12,14 @@ func TestLoadConfig(t *testing.T) {
 	os.Setenv("DB_PORT", "1337")
 	os.Setenv("DB_USER", "sample_user")
 	os.Setenv("DB_PASS", "sample_pass")
+	os.Setenv("AUTH0_URL", "https://auth0.com/test")
 
 	defer func() {
 		os.Unsetenv("DB_HOST")
 		os.Unsetenv("DB_PORT")
 		os.Unsetenv("DB_USER")
 		os.Unsetenv("DB_PASS")
+		os.Unsetenv("AUTH0_URL")
 	}()
 
 	cfg := LoadConfig()
@@ -25,6 +28,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, "1337", cfg.Db.Port)
 	assert.Equal(t, "sample_user", cfg.Db.User)
 	assert.Equal(t, "sample_pass", cfg.Db.Password)
+	assert.Equal(t, url.URL{Scheme: "https", Host: "auth0.com", Path: "/test"}, cfg.Auth0.Url)
 }
 
 func TestFallbackValues(t *testing.T) {
@@ -34,4 +38,5 @@ func TestFallbackValues(t *testing.T) {
 	assert.Equal(t, "5432", cfg.Db.Port)
 	assert.Equal(t, "postgres", cfg.Db.User)
 	assert.Equal(t, "postgres", cfg.Db.Password)
+	assert.Equal(t, url.URL{Scheme: "http", Host: "localhost"}, cfg.Auth0.Url)
 }

--- a/src/provisioning/internal/service/auth.go
+++ b/src/provisioning/internal/service/auth.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/Lachstec/mc-hosting/internal/types"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+type AuthService struct {
+	serviceUrl url.URL
+	client     http.Client
+}
+
+func NewAuthService(auth0 url.URL) *AuthService {
+	return &AuthService{
+		serviceUrl: auth0,
+		client:     http.Client{},
+	}
+}
+
+func (s *AuthService) ValidateToken(token string) (*types.UserInfo, error) {
+	req, err := http.NewRequest("GET", s.serviceUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("invalid token")
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var userinfo types.UserInfo
+	fmt.Println(string(body))
+	err = json.Unmarshal(body, &userinfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return &userinfo, nil
+}

--- a/src/provisioning/internal/service/auth.go
+++ b/src/provisioning/internal/service/auth.go
@@ -9,11 +9,14 @@ import (
 	"net/url"
 )
 
+// AuthService provides functions for checking if a user is authenticated
+// or extracting user info from it.
 type AuthService struct {
 	serviceUrl url.URL
 	client     http.Client
 }
 
+// NewAuthService creates a new AuthenticationService that asks the auth0 url
 func NewAuthService(auth0 url.URL) *AuthService {
 	return &AuthService{
 		serviceUrl: auth0,
@@ -21,6 +24,8 @@ func NewAuthService(auth0 url.URL) *AuthService {
 	}
 }
 
+// ValidateToken sends the given token to Auth0 in order to obtain
+// user information. If an error occurs, the user is to be treated as not authorized.
 func (s *AuthService) ValidateToken(token string) (*types.UserInfo, error) {
 	req, err := http.NewRequest("GET", s.serviceUrl.String(), nil)
 	if err != nil {

--- a/src/provisioning/internal/types/userinfo.go
+++ b/src/provisioning/internal/types/userinfo.go
@@ -1,0 +1,5 @@
+package types
+
+type UserInfo struct {
+	Sub string `json:"sub"`
+}


### PR DESCRIPTION
Die PR fügt einen neuen Service `AuthService` hinzu, der mithilfe von einem Auth0 Token die dazugehörigen Infos über den User abfragen kann. Config wurde geupdated, eine Auth0 URL zu erhalten.